### PR TITLE
fix: Application start exception

### DIFF
--- a/src/main/java/cn/auroralab/devtrack/entity/Accounts.java
+++ b/src/main/java/cn/auroralab/devtrack/entity/Accounts.java
@@ -20,14 +20,13 @@ import lombok.EqualsAndHashCode;
 @Data
 @EqualsAndHashCode(callSuper = false)
 public class Accounts implements Serializable {
-
     private static final long serialVersionUID = 1L;
 
     /**
      * 用户uuid
      */
-    @TableId(type = IdType.INPUT)
-    private byte[] userUuid;
+    @TableId(value = "user_uuid", type = IdType.INPUT)
+    private byte[] uuid;
 
     /**
      * 用户名
@@ -73,6 +72,4 @@ public class Accounts implements Serializable {
      * 上次登录时间
      */
     private LocalDateTime lastLoginTime;
-
-
 }

--- a/src/main/java/cn/auroralab/devtrack/entity/Accounts.java
+++ b/src/main/java/cn/auroralab/devtrack/entity/Accounts.java
@@ -4,6 +4,8 @@ import java.time.LocalDateTime;
 import java.sql.Blob;
 import java.io.Serializable;
 
+import com.baomidou.mybatisplus.annotation.IdType;
+import com.baomidou.mybatisplus.annotation.TableId;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 
@@ -24,6 +26,7 @@ public class Accounts implements Serializable {
     /**
      * 用户uuid
      */
+    @TableId(type = IdType.INPUT)
     private byte[] userUuid;
 
     /**

--- a/src/main/java/cn/auroralab/devtrack/entity/ProjectMembers.java
+++ b/src/main/java/cn/auroralab/devtrack/entity/ProjectMembers.java
@@ -18,14 +18,13 @@ import lombok.EqualsAndHashCode;
 @Data
 @EqualsAndHashCode(callSuper = false)
 public class ProjectMembers implements Serializable {
-
     private static final long serialVersionUID = 1L;
 
     /**
      * 映射记录uuid
      */
-    @TableId(type = IdType.INPUT)
-    private byte[] recordUuid;
+    @TableId(value = "record_uuid", type = IdType.INPUT)
+    private byte[] uuid;
 
     /**
      * 项目uuid
@@ -46,6 +45,4 @@ public class ProjectMembers implements Serializable {
      * 用户在项目中扮演的角色
      */
     private byte[] roleUuid;
-
-
 }

--- a/src/main/java/cn/auroralab/devtrack/entity/ProjectMembers.java
+++ b/src/main/java/cn/auroralab/devtrack/entity/ProjectMembers.java
@@ -2,6 +2,8 @@ package cn.auroralab.devtrack.entity;
 
 import java.io.Serializable;
 
+import com.baomidou.mybatisplus.annotation.IdType;
+import com.baomidou.mybatisplus.annotation.TableId;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 
@@ -22,6 +24,7 @@ public class ProjectMembers implements Serializable {
     /**
      * 映射记录uuid
      */
+    @TableId(type = IdType.INPUT)
     private byte[] recordUuid;
 
     /**

--- a/src/main/java/cn/auroralab/devtrack/entity/ProjectRoles.java
+++ b/src/main/java/cn/auroralab/devtrack/entity/ProjectRoles.java
@@ -18,14 +18,13 @@ import lombok.EqualsAndHashCode;
 @Data
 @EqualsAndHashCode(callSuper = false)
 public class ProjectRoles implements Serializable {
-
     private static final long serialVersionUID = 1L;
 
     /**
      * 角色uuid
      */
-    @TableId(type = IdType.INPUT)
-    private byte[] roleUuid;
+    @TableId(value = "role_uuid", type = IdType.INPUT)
+    private byte[] uuid;
 
     /**
      * 角色所属项目的uuid
@@ -66,6 +65,4 @@ public class ProjectRoles implements Serializable {
      * 删除任务权限
      */
     private Boolean deleteTask;
-
-
 }

--- a/src/main/java/cn/auroralab/devtrack/entity/ProjectRoles.java
+++ b/src/main/java/cn/auroralab/devtrack/entity/ProjectRoles.java
@@ -2,6 +2,8 @@ package cn.auroralab.devtrack.entity;
 
 import java.io.Serializable;
 
+import com.baomidou.mybatisplus.annotation.IdType;
+import com.baomidou.mybatisplus.annotation.TableId;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 
@@ -22,6 +24,7 @@ public class ProjectRoles implements Serializable {
     /**
      * 角色uuid
      */
+    @TableId(type = IdType.INPUT)
     private byte[] roleUuid;
 
     /**

--- a/src/main/java/cn/auroralab/devtrack/entity/ProjectTasks.java
+++ b/src/main/java/cn/auroralab/devtrack/entity/ProjectTasks.java
@@ -3,6 +3,8 @@ package cn.auroralab.devtrack.entity;
 import java.time.LocalDateTime;
 import java.io.Serializable;
 
+import com.baomidou.mybatisplus.annotation.IdType;
+import com.baomidou.mybatisplus.annotation.TableId;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 
@@ -23,6 +25,7 @@ public class ProjectTasks implements Serializable {
     /**
      * 任务uuid
      */
+    @TableId(type = IdType.INPUT)
     private byte[] taskUuid;
 
     /**

--- a/src/main/java/cn/auroralab/devtrack/entity/ProjectTasks.java
+++ b/src/main/java/cn/auroralab/devtrack/entity/ProjectTasks.java
@@ -19,14 +19,13 @@ import lombok.EqualsAndHashCode;
 @Data
 @EqualsAndHashCode(callSuper = false)
 public class ProjectTasks implements Serializable {
-
     private static final long serialVersionUID = 1L;
 
     /**
      * 任务uuid
      */
-    @TableId(type = IdType.INPUT)
-    private byte[] taskUuid;
+    @TableId(value = "task_uuid", type = IdType.INPUT)
+    private byte[] uuid;
 
     /**
      * 任务所属的项目uuid
@@ -112,6 +111,4 @@ public class ProjectTasks implements Serializable {
      * 任务删除时间
      */
     private LocalDateTime deleteTime;
-
-
 }

--- a/src/main/java/cn/auroralab/devtrack/entity/Projects.java
+++ b/src/main/java/cn/auroralab/devtrack/entity/Projects.java
@@ -3,6 +3,8 @@ package cn.auroralab.devtrack.entity;
 import java.time.LocalDateTime;
 import java.io.Serializable;
 
+import com.baomidou.mybatisplus.annotation.IdType;
+import com.baomidou.mybatisplus.annotation.TableId;
 import lombok.Data;
 import lombok.EqualsAndHashCode;
 
@@ -23,6 +25,7 @@ public class Projects implements Serializable {
     /**
      * 项目uuid
      */
+    @TableId(type = IdType.INPUT)
     private byte[] projectUuid;
 
     /**

--- a/src/main/java/cn/auroralab/devtrack/entity/Projects.java
+++ b/src/main/java/cn/auroralab/devtrack/entity/Projects.java
@@ -19,14 +19,13 @@ import lombok.EqualsAndHashCode;
 @Data
 @EqualsAndHashCode(callSuper = false)
 public class Projects implements Serializable {
-
     private static final long serialVersionUID = 1L;
 
     /**
      * 项目uuid
      */
-    @TableId(type = IdType.INPUT)
-    private byte[] projectUuid;
+    @TableId(value = "project_uuid", type = IdType.INPUT)
+    private byte[] uuid;
 
     /**
      * 项目的数字id
@@ -82,6 +81,4 @@ public class Projects implements Serializable {
      * 项目删除时间
      */
     private LocalDateTime deleteTime;
-
-
 }

--- a/src/main/java/cn/auroralab/devtrack/mapper/AccountsMapper.java
+++ b/src/main/java/cn/auroralab/devtrack/mapper/AccountsMapper.java
@@ -2,6 +2,7 @@ package cn.auroralab.devtrack.mapper;
 
 import cn.auroralab.devtrack.entity.Accounts;
 import com.baomidou.mybatisplus.core.mapper.BaseMapper;
+import org.apache.ibatis.annotations.Mapper;
 
 /**
  * <p>
@@ -11,6 +12,7 @@ import com.baomidou.mybatisplus.core.mapper.BaseMapper;
  * @author Guanyu Hu
  * @since 2022-10-14
  */
+@Mapper
 public interface AccountsMapper extends BaseMapper<Accounts> {
 
 }

--- a/src/main/java/cn/auroralab/devtrack/mapper/ProjectMembersMapper.java
+++ b/src/main/java/cn/auroralab/devtrack/mapper/ProjectMembersMapper.java
@@ -2,6 +2,7 @@ package cn.auroralab.devtrack.mapper;
 
 import cn.auroralab.devtrack.entity.ProjectMembers;
 import com.baomidou.mybatisplus.core.mapper.BaseMapper;
+import org.apache.ibatis.annotations.Mapper;
 
 /**
  * <p>
@@ -11,6 +12,7 @@ import com.baomidou.mybatisplus.core.mapper.BaseMapper;
  * @author Guanyu Hu
  * @since 2022-10-14
  */
+@Mapper
 public interface ProjectMembersMapper extends BaseMapper<ProjectMembers> {
 
 }

--- a/src/main/java/cn/auroralab/devtrack/mapper/ProjectRolesMapper.java
+++ b/src/main/java/cn/auroralab/devtrack/mapper/ProjectRolesMapper.java
@@ -2,6 +2,7 @@ package cn.auroralab.devtrack.mapper;
 
 import cn.auroralab.devtrack.entity.ProjectRoles;
 import com.baomidou.mybatisplus.core.mapper.BaseMapper;
+import org.apache.ibatis.annotations.Mapper;
 
 /**
  * <p>
@@ -11,6 +12,7 @@ import com.baomidou.mybatisplus.core.mapper.BaseMapper;
  * @author Guanyu Hu
  * @since 2022-10-14
  */
+@Mapper
 public interface ProjectRolesMapper extends BaseMapper<ProjectRoles> {
 
 }

--- a/src/main/java/cn/auroralab/devtrack/mapper/ProjectTasksMapper.java
+++ b/src/main/java/cn/auroralab/devtrack/mapper/ProjectTasksMapper.java
@@ -2,6 +2,7 @@ package cn.auroralab.devtrack.mapper;
 
 import cn.auroralab.devtrack.entity.ProjectTasks;
 import com.baomidou.mybatisplus.core.mapper.BaseMapper;
+import org.apache.ibatis.annotations.Mapper;
 
 /**
  * <p>
@@ -11,6 +12,7 @@ import com.baomidou.mybatisplus.core.mapper.BaseMapper;
  * @author Guanyu Hu
  * @since 2022-10-14
  */
+@Mapper
 public interface ProjectTasksMapper extends BaseMapper<ProjectTasks> {
 
 }

--- a/src/main/java/cn/auroralab/devtrack/mapper/ProjectsMapper.java
+++ b/src/main/java/cn/auroralab/devtrack/mapper/ProjectsMapper.java
@@ -2,6 +2,7 @@ package cn.auroralab.devtrack.mapper;
 
 import cn.auroralab.devtrack.entity.Projects;
 import com.baomidou.mybatisplus.core.mapper.BaseMapper;
+import org.apache.ibatis.annotations.Mapper;
 
 /**
  * <p>
@@ -11,6 +12,7 @@ import com.baomidou.mybatisplus.core.mapper.BaseMapper;
  * @author Guanyu Hu
  * @since 2022-10-14
  */
+@Mapper
 public interface ProjectsMapper extends BaseMapper<Projects> {
 
 }

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,7 +1,0 @@
-server.port=8181
-spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver
-spring.datasource.url=jdbc:mysql://auroralab.mysql.rds.aliyuncs.com:3306/devtrack_database
-spring.datasource.username=devtrack
-spring.datasource.password=DevTrack@2022
-mybatis-plus.configuration.log-impl=org.apache.ibatis.logging.stdout.StdOutImpl
-mybatis-plus.mapper-locations=cn/auroralab/devtrack/mapper/xml/*.xml

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,0 +1,12 @@
+server:
+    port: 8181
+spring:
+    datasource:
+        driver-class-name: com.mysql.cj.jdbc.Driver
+        url: jdbc:mysql://auroralab.mysql.rds.aliyuncs.com:3306/devtrack_database
+        username: devtrack
+        password: DevTrack@2022
+mybatis-plus:
+    configuration:
+        log-impl: org.apache.ibatis.logging.stdout.StdOutImpl
+    mapper-locations: cn/auroralab/devtrack/mapper/xml/*.xml


### PR DESCRIPTION
# fix: Application start exception

## Description

The application cannot be started because class that extends BaseMapper does not load Mapper annotations.

## List

- Add Mapper annotation to the class that extends BaseMapper.
- Mark the primary key of the entities.
- Rename the primary key members that include in entities.
- Code formatting.

## Checklist

- [x] Added description of change.
- [x] Add doc of change.